### PR TITLE
Performance fix to skip retries if there is no error

### DIFF
--- a/block/provider/detach_volume.go
+++ b/block/provider/detach_volume.go
@@ -61,7 +61,10 @@ func (vpcs *VPCSession) DetachVolume(volumeAttachmentTemplate provider.VolumeAtt
 			volumeAttachment.ID = currentVolAttachment.VPCVolumeAttachment.ID
 			vpcs.Logger.Info("Detaching volume from VPC provider...")
 			response, err = vpcs.APIClientVolAttachMgr.DetachVolume(&volumeAttachment, vpcs.Logger) //nolint:bodyclose
-			return err, skipRetryForObviousErrors(err, vpcs.Config.VPCConfig.IsIKS)                 // Retry in case of all errors
+
+			if err != nil {
+				return err, skipRetryForObviousErrors(err, vpcs.Config.VPCConfig.IsIKS) // Retry in case of all errors
+			}
 		}
 		vpcs.Logger.Info("No volume attachment found for", zap.Reflect("currentVolAttachment", currentVolAttachment), zap.Error(err))
 		// consider volume detach success if its  already  in Detaching or VolumeAttachment is not found

--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -198,7 +198,7 @@ func (fRetry *FlexyRetry) FlexyRetryWithConstGap(logger *zap.Logger, funcToRetry
 	var err error
 	var stopRetry bool
 	// lets have more number of try for wait for attach and detach specially
-	totalAttempt := fRetry.maxRetryAttempt * 4 // 40 time as per default values i.e 400 seconds
+	totalAttempt := fRetry.maxRetryAttempt * 8 // 80 time as per default values i.e 400 seconds
 	for i := 0; i < totalAttempt; i++ {
 		if i > 0 {
 			time.Sleep(time.Duration(ConstantRetryGap) * time.Second)

--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -39,7 +39,7 @@ var retryGap = 10
 
 //ConstantRetryGap ...
 const (
-	ConstantRetryGap = 10 // seconds
+	ConstantRetryGap = 5 // seconds
 )
 
 var volumeIDPartsCount = 5
@@ -70,7 +70,7 @@ var skipErrorCodes = map[string]bool{
 // retry ...
 func retry(logger *zap.Logger, retryfunc func() error) error {
 	var err error
-
+	retryGap = 10
 	for i := 0; i < maxRetryAttempt; i++ {
 		if i > 0 {
 			time.Sleep(time.Duration(retryGap) * time.Second)
@@ -166,6 +166,7 @@ func NewFlexyRetry(maxRtyAtmpt int, maxrRtyGap int) FlexyRetry {
 func (fRetry *FlexyRetry) FlexyRetry(logger *zap.Logger, funcToRetry func() (error, bool)) error {
 	var err error
 	var stopRetry bool
+	retryGap = 10
 	for i := 0; i < fRetry.maxRetryAttempt; i++ {
 		if i > 0 {
 			time.Sleep(time.Duration(retryGap) * time.Second)

--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -34,12 +34,9 @@ var maxRetryAttempt = 10
 // maxRetryGap ...
 var maxRetryGap = 60
 
-// retryGap ...
-//var retryGap = 10
-
 //ConstantRetryGap ...
 const (
-	ConstantRetryGap = 5 // seconds
+	ConstantRetryGap = 10 // seconds
 )
 
 var volumeIDPartsCount = 5
@@ -198,7 +195,7 @@ func (fRetry *FlexyRetry) FlexyRetryWithConstGap(logger *zap.Logger, funcToRetry
 	var err error
 	var stopRetry bool
 	// lets have more number of try for wait for attach and detach specially
-	totalAttempt := fRetry.maxRetryAttempt * 8 // 80 time as per default values i.e 400 seconds
+	totalAttempt := fRetry.maxRetryAttempt * 4 // 40 time as per default values i.e 400 seconds
 	for i := 0; i < totalAttempt; i++ {
 		if i > 0 {
 			time.Sleep(time.Duration(ConstantRetryGap) * time.Second)

--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -35,7 +35,7 @@ var maxRetryAttempt = 10
 var maxRetryGap = 60
 
 // retryGap ...
-var retryGap = 10
+//var retryGap = 10
 
 //ConstantRetryGap ...
 const (
@@ -70,7 +70,7 @@ var skipErrorCodes = map[string]bool{
 // retry ...
 func retry(logger *zap.Logger, retryfunc func() error) error {
 	var err error
-	retryGap = 10
+	retryGap := 10
 	for i := 0; i < maxRetryAttempt; i++ {
 		if i > 0 {
 			time.Sleep(time.Duration(retryGap) * time.Second)
@@ -166,7 +166,7 @@ func NewFlexyRetry(maxRtyAtmpt int, maxrRtyGap int) FlexyRetry {
 func (fRetry *FlexyRetry) FlexyRetry(logger *zap.Logger, funcToRetry func() (error, bool)) error {
 	var err error
 	var stopRetry bool
-	retryGap = 10
+	retryGap := 10
 	for i := 0; i < fRetry.maxRetryAttempt; i++ {
 		if i > 0 {
 			time.Sleep(time.Duration(retryGap) * time.Second)


### PR DESCRIPTION
Performance fix takes care of 2 things in this PR 

1.) Detach was doing unnecessary retry for detach API call on success
2.) Retrygap variable was global and not thread safe. So it was in holding unwanted value on each exponential retry for Attach/Detach calls.