### PR TITLE
Support to honour custom retry gaps for attach/detach

### DIFF
--- a/block/provider/provider.go
+++ b/block/provider/provider.go
@@ -226,6 +226,21 @@ func (vpcp *VPCBlockProvider) OpenSession(ctx context.Context, contextCredential
 		maxRetryGap = vpcp.Config.VPCConfig.MaxRetryGap
 	}
 
+	// Update retry logic default values
+	/*if vpcp.Config.VPCConfig.MinVPCRetryGap > 3 && vpcp.Config.VPCConfig.MinVPCRetryGap < 10 {
+		ctxLogger.Debug("", zap.Reflect("MinVPCRetryGap", vpcp.Config.VPCConfig.MinVPCRetryGap))
+		minVPCRetryGap = vpcp.Config.VPCConfig.MinVPCRetryGap
+	}
+	if vpcp.Config.VPCConfig.MinVPCRetryGapAttempt > 0 {
+		ctxLogger.Debug("", zap.Reflect("MinVPCRetryGapAttempt", vpcp.Config.VPCConfig.MinVPCRetryGapAttempt))
+		minVPCRetryGapAttempt = vpcp.Config.VPCConfig.MinVPCRetryGapAttempt
+	}
+
+	if vpcp.Config.VPCConfig.MaxVPCRetryAttempt > 46 {
+		ctxLogger.Debug("", zap.Reflect("MaxVPCRetryAttempt", vpcp.Config.VPCConfig.MaxVPCRetryAttempt))
+		maxVPCRetryAttempt = vpcp.Config.VPCConfig.MaxVPCRetryAttempt
+	}*/
+
 	vpcSession := &VPCSession{
 		VPCAccountID:          contextCredentials.IAMAccountID,
 		Config:                vpcp.Config,

--- a/block/provider/provider.go
+++ b/block/provider/provider.go
@@ -227,7 +227,7 @@ func (vpcp *VPCBlockProvider) OpenSession(ctx context.Context, contextCredential
 	}
 
 	//Update retry logic for custom retry with default values
-	if vpcp.Config.VPCConfig.MinVPCRetryGap > 3 && vpcp.Config.VPCConfig.MinVPCRetryGap < 10 {
+	if vpcp.Config.VPCConfig.MinVPCRetryGap > ConstMinVPCRetryGap && vpcp.Config.VPCConfig.MinVPCRetryGap < ConstantRetryGap {
 		ctxLogger.Debug("", zap.Reflect("MinVPCRetryGap", vpcp.Config.VPCConfig.MinVPCRetryGap))
 		minVPCRetryGap = vpcp.Config.VPCConfig.MinVPCRetryGap
 	}
@@ -236,7 +236,7 @@ func (vpcp *VPCBlockProvider) OpenSession(ctx context.Context, contextCredential
 		minVPCRetryGapAttempt = vpcp.Config.VPCConfig.MinVPCRetryGapAttempt
 	}
 
-	if vpcp.Config.VPCConfig.MaxVPCRetryAttempt > 46 {
+	if vpcp.Config.VPCConfig.MaxVPCRetryAttempt > ConstMaxVPCRetryAttempt {
 		ctxLogger.Debug("", zap.Reflect("MaxVPCRetryAttempt", vpcp.Config.VPCConfig.MaxVPCRetryAttempt))
 		maxVPCRetryAttempt = vpcp.Config.VPCConfig.MaxVPCRetryAttempt
 	}

--- a/block/provider/provider.go
+++ b/block/provider/provider.go
@@ -226,7 +226,7 @@ func (vpcp *VPCBlockProvider) OpenSession(ctx context.Context, contextCredential
 		maxRetryGap = vpcp.Config.VPCConfig.MaxRetryGap
 	}
 
-	//Update retry logic default values
+	//Update retry logic for custom retry with default values
 	if vpcp.Config.VPCConfig.MinVPCRetryGap > 3 && vpcp.Config.VPCConfig.MinVPCRetryGap < 10 {
 		ctxLogger.Debug("", zap.Reflect("MinVPCRetryGap", vpcp.Config.VPCConfig.MinVPCRetryGap))
 		minVPCRetryGap = vpcp.Config.VPCConfig.MinVPCRetryGap

--- a/block/provider/provider.go
+++ b/block/provider/provider.go
@@ -226,8 +226,8 @@ func (vpcp *VPCBlockProvider) OpenSession(ctx context.Context, contextCredential
 		maxRetryGap = vpcp.Config.VPCConfig.MaxRetryGap
 	}
 
-	// Update retry logic default values
-	/*if vpcp.Config.VPCConfig.MinVPCRetryGap > 3 && vpcp.Config.VPCConfig.MinVPCRetryGap < 10 {
+	//Update retry logic default values
+	if vpcp.Config.VPCConfig.MinVPCRetryGap > 3 && vpcp.Config.VPCConfig.MinVPCRetryGap < 10 {
 		ctxLogger.Debug("", zap.Reflect("MinVPCRetryGap", vpcp.Config.VPCConfig.MinVPCRetryGap))
 		minVPCRetryGap = vpcp.Config.VPCConfig.MinVPCRetryGap
 	}
@@ -239,7 +239,7 @@ func (vpcp *VPCBlockProvider) OpenSession(ctx context.Context, contextCredential
 	if vpcp.Config.VPCConfig.MaxVPCRetryAttempt > 46 {
 		ctxLogger.Debug("", zap.Reflect("MaxVPCRetryAttempt", vpcp.Config.VPCConfig.MaxVPCRetryAttempt))
 		maxVPCRetryAttempt = vpcp.Config.VPCConfig.MaxVPCRetryAttempt
-	}*/
+	}
 
 	vpcSession := &VPCSession{
 		VPCAccountID:          contextCredentials.IAMAccountID,

--- a/block/provider/provider.go
+++ b/block/provider/provider.go
@@ -227,6 +227,12 @@ func (vpcp *VPCBlockProvider) OpenSession(ctx context.Context, contextCredential
 	}
 
 	//Update retry logic for custom retry with default values
+	/*
+		Default MaxVPCRetryAttempt = 46 times(~7 mins), MinVPCRetryGap = 3sec , MinVPCRetryGapAttempt = 3sec
+		1.) Honour the MinVPCRetryGap only if it is greater than 3 and less than 10 sec
+		2.) Honour the MinVPCRetryGapAttempt only if it is greater than 0
+		3.) Honour the MaxVPCRetryAttempt only if it is greater than 46 ( ~7 mins default)
+	*/
 	if vpcp.Config.VPCConfig.MinVPCRetryGap > ConstMinVPCRetryGap && vpcp.Config.VPCConfig.MinVPCRetryGap < ConstantRetryGap {
 		minVPCRetryGap = vpcp.Config.VPCConfig.MinVPCRetryGap
 	}

--- a/block/provider/provider.go
+++ b/block/provider/provider.go
@@ -228,18 +228,18 @@ func (vpcp *VPCBlockProvider) OpenSession(ctx context.Context, contextCredential
 
 	//Update retry logic for custom retry with default values
 	if vpcp.Config.VPCConfig.MinVPCRetryGap > ConstMinVPCRetryGap && vpcp.Config.VPCConfig.MinVPCRetryGap < ConstantRetryGap {
-		ctxLogger.Debug("", zap.Reflect("MinVPCRetryGap", vpcp.Config.VPCConfig.MinVPCRetryGap))
 		minVPCRetryGap = vpcp.Config.VPCConfig.MinVPCRetryGap
 	}
+
 	if vpcp.Config.VPCConfig.MinVPCRetryGapAttempt > 0 {
-		ctxLogger.Debug("", zap.Reflect("MinVPCRetryGapAttempt", vpcp.Config.VPCConfig.MinVPCRetryGapAttempt))
 		minVPCRetryGapAttempt = vpcp.Config.VPCConfig.MinVPCRetryGapAttempt
 	}
 
 	if vpcp.Config.VPCConfig.MaxVPCRetryAttempt > ConstMaxVPCRetryAttempt {
-		ctxLogger.Debug("", zap.Reflect("MaxVPCRetryAttempt", vpcp.Config.VPCConfig.MaxVPCRetryAttempt))
 		maxVPCRetryAttempt = vpcp.Config.VPCConfig.MaxVPCRetryAttempt
 	}
+
+	ctxLogger.Info("VPC Retry details for WaitAttach and WaitDetach operations", zap.Reflect("MinVPCRetryGap", minVPCRetryGap), zap.Reflect("MinVPCRetryGapAttempt", minVPCRetryGapAttempt), zap.Reflect("MaxVPCRetryAttempt", maxVPCRetryAttempt))
 
 	vpcSession := &VPCSession{
 		VPCAccountID:          contextCredentials.IAMAccountID,

--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -41,7 +41,7 @@ var minVPCRetryGap = 3
 var minVPCRetryGapAttempt = 3
 
 // maxRetryAttempt ...
-var maxVPCRetryAttempt = 20
+var maxVPCRetryAttempt = 46
 
 //ConstantRetryGap ...
 const (

--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -29,10 +29,10 @@ import (
 )
 
 // maxRetryAttempt ...
-var maxRetryAttempt = 0
+var maxRetryAttempt = 10
 
 // maxRetryGap ...
-var maxRetryGap = 0
+var maxRetryGap = 60
 
 // minVPCRetryGap ...
 var minVPCRetryGap = 3

--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -259,7 +259,7 @@ func (fRetry *FlexyRetry) FlexyRetryWithCustomGap(logger *zap.Logger, funcToRetr
 		}
 
 		//Remaining attempts 10 seconds
-		if (i + 1) == ((2 * fRetry.minVPCRetryGapAttempt) + fRetry.minVPCRetryGapAttempt) {
+		if i == ((2 * fRetry.minVPCRetryGapAttempt) + fRetry.minVPCRetryGapAttempt) {
 			retryGap = 10 // 10 seconds
 		}
 

--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -45,7 +45,9 @@ var maxVPCRetryAttempt = 46
 
 //ConstantRetryGap ...
 const (
-	ConstantRetryGap = 10 // seconds
+	ConstantRetryGap        = 10 // seconds
+	ConstMaxVPCRetryAttempt = 46
+	ConstMinVPCRetryGap     = 3 //seconds
 )
 
 var volumeIDPartsCount = 5

--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -251,16 +251,16 @@ func (fRetry *FlexyRetry) FlexyRetryWithCustomGap(logger *zap.Logger, funcToRetr
 
 		//First fRetry.minVPCRetryGapAttempt attempts fRetry.minVPCRetryGap second and next (2 * fRetry.minVPCRetryGap)  attempts (2 * fRetry.minVPCRetryGap) second
 		if i == fRetry.minVPCRetryGapAttempt {
-			if (2 * fRetry.minVPCRetryGap) < 10 { //If minVPCRetryGap is resulting in value more than 10 secs lets default to 10 secs
+			if (2 * fRetry.minVPCRetryGap) < ConstantRetryGap { //If minVPCRetryGap is resulting in value more than 10 secs lets default to 10 secs
 				retryGap = 2 * fRetry.minVPCRetryGap
 			} else {
-				retryGap = 10
+				retryGap = ConstantRetryGap
 			}
 		}
 
 		//Remaining attempts 10 seconds
 		if i == ((2 * fRetry.minVPCRetryGapAttempt) + fRetry.minVPCRetryGapAttempt) {
-			retryGap = 10 // 10 seconds
+			retryGap = ConstantRetryGap // 10 seconds
 		}
 
 		if (i + 1) < totalAttempt {

--- a/block/provider/util_test.go
+++ b/block/provider/util_test.go
@@ -101,6 +101,7 @@ func TestFlexyRetryWithCustomGap(t *testing.T) {
 
 	customRetry := NewFlexyRetryDefault()
 
+	//Testing retry with successful attempt
 	err = customRetry.FlexyRetryWithCustomGap(logger, func() (error, bool) {
 		logger.Info("Testing retry with successful attempt")
 		if attempt == 2 {
@@ -121,6 +122,7 @@ func TestFlexyRetryWithCustomGap(t *testing.T) {
 		return err, skip
 	})
 
+	//Testing retry with unsuccessful attempt
 	err = customRetry.FlexyRetryWithCustomGap(logger, func() (error, bool) {
 		logger.Info("Testing retry with unsuccessful attempt")
 		errCode := models.ErrorCode("wrong_code")
@@ -134,6 +136,7 @@ func TestFlexyRetryWithCustomGap(t *testing.T) {
 		return err, false
 	})
 
+	//Testing retry with unsuccessful attempt with custom gap
 	customRetry.minVPCRetryGap = 6
 	customRetry.minVPCRetryGapAttempt = 6
 

--- a/block/provider/util_test.go
+++ b/block/provider/util_test.go
@@ -92,6 +92,66 @@ func TestRetry(t *testing.T) {
 	})
 }
 
+func TestFlexyRetryWithCustomGap(t *testing.T) {
+	// Setup new style zap logger
+	logger, _ := GetTestContextLogger()
+	var err error
+	var attempt = 0
+	var skip = false
+
+	customRetry := NewFlexyRetryDefault()
+
+	err = customRetry.FlexyRetryWithCustomGap(logger, func() (error, bool) {
+		logger.Info("Testing retry with successful attempt")
+		if attempt == 2 {
+			err = nil
+			skip = true
+		} else {
+			errCode := models.ErrorCode("validation_invalid_name")
+			errItem := models.ErrorItem{
+				Code: errCode,
+			}
+
+			err = &models.Error{
+				Errors: []models.ErrorItem{errItem},
+			}
+			skip = false
+		}
+		attempt = attempt + 1
+		return err, skip
+	})
+
+	err = customRetry.FlexyRetryWithCustomGap(logger, func() (error, bool) {
+		logger.Info("Testing retry with unsuccessful attempt")
+		errCode := models.ErrorCode("wrong_code")
+		errItem := models.ErrorItem{
+			Code: errCode,
+		}
+
+		err = &models.Error{
+			Errors: []models.ErrorItem{errItem},
+		}
+		return err, false
+	})
+
+	customRetry.minVPCRetryGap = 6
+	customRetry.minVPCRetryGapAttempt = 6
+
+	err = customRetry.FlexyRetryWithCustomGap(logger, func() (error, bool) {
+		logger.Info("Testing retry with unsuccessful attempt with custom gap")
+		errCode := models.ErrorCode("wrong_code")
+		errItem := models.ErrorItem{
+			Code: errCode,
+		}
+
+		err = &models.Error{
+			Errors: []models.ErrorItem{errItem},
+		}
+		return err, false
+	})
+
+}
+
 func TestSkipRetry(t *testing.T) {
 	errCode := models.ErrorCode("validation_invalid_name")
 	errItem := models.ErrorItem{

--- a/block/provider/wait_for_attach_volume.go
+++ b/block/provider/wait_for_attach_volume.go
@@ -45,7 +45,7 @@ func (vpcs *VPCSession) WaitForAttachVolume(volumeAttachmentTemplate provider.Vo
 	}
 
 	var currentVolAttachment *provider.VolumeAttachmentResponse
-	err = vpcs.APIRetry.FlexyRetryWithConstGap(vpcs.Logger, func() (error, bool) {
+	err = vpcs.APIRetry.FlexyRetryWithCustomGap(vpcs.Logger, func() (error, bool) {
 		currentVolAttachment, err = vpcs.GetVolumeAttachment(volumeAttachmentTemplate)
 		if err != nil {
 			// Need to stop retry as there is an error while getting attachment

--- a/block/provider/wait_for_detach_volume.go
+++ b/block/provider/wait_for_detach_volume.go
@@ -45,7 +45,7 @@ func (vpcs *VPCSession) WaitForDetachVolume(volumeAttachmentTemplate provider.Vo
 		return err
 	}
 
-	err = vpcs.APIRetry.FlexyRetryWithConstGap(vpcs.Logger, func() (error, bool) {
+	err = vpcs.APIRetry.FlexyRetryWithCustomGap(vpcs.Logger, func() (error, bool) {
 		_, err := vpcs.GetVolumeAttachment(volumeAttachmentTemplate)
 		// In case of error we should not retry as there are two conditions for error
 		// 1- some issues at endpoint side --> Which is already covered in vpcs.GetVolumeAttachment

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7
-	github.com/IBM/ibmcloud-volume-interface v1.0.1-beta6.0.20220915095958-58768b1f060e
+	github.com/IBM/ibmcloud-volume-interface v1.0.1-beta7
 	github.com/IBM/secret-common-lib v1.0.3
 	github.com/IBM/secret-utils-lib v1.0.2
 	github.com/fatih/structs v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7
-	github.com/IBM/ibmcloud-volume-interface v1.0.1-beta6
+	github.com/IBM/ibmcloud-volume-interface v1.0.1-beta6.0.20220915095958-58768b1f060e
 	github.com/IBM/secret-common-lib v1.0.3
 	github.com/IBM/secret-utils-lib v1.0.2
 	github.com/fatih/structs v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7 h1:eHgfQl6IeSmzWUyiSi13CvoFYsovoyq
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM/go-sdk-core/v5 v5.9.1 h1:06pXbD9Rgmqqe2HA5YAeQbB4eYRRFgIoOT+Kh3cp1zo=
 github.com/IBM/go-sdk-core/v5 v5.9.1/go.mod h1:axE2JrRq79gIJTjKPBwV6gWHswvVptBjbcvvCPIxARM=
-github.com/IBM/ibmcloud-volume-interface v1.0.1-beta6 h1:bzMUTWuiNVzdHOXXhoy8L7HcvcGQxznvrIGfWGKjVf4=
-github.com/IBM/ibmcloud-volume-interface v1.0.1-beta6/go.mod h1:v1aT8G3Tib8pCwdr9VweNFYa94GejBuqIVTysoaVI0g=
+github.com/IBM/ibmcloud-volume-interface v1.0.1-beta6.0.20220915095958-58768b1f060e h1:YwViMVC1SJebTuc5UiaOTP2g02DVuPj8A8i7Ft75oBc=
+github.com/IBM/ibmcloud-volume-interface v1.0.1-beta6.0.20220915095958-58768b1f060e/go.mod h1:v1aT8G3Tib8pCwdr9VweNFYa94GejBuqIVTysoaVI0g=
 github.com/IBM/secret-common-lib v1.0.3 h1:rhhAtAE1ANSuxhA8Nulzzc2IbXWHGE8reoRSr98rRi8=
 github.com/IBM/secret-common-lib v1.0.3/go.mod h1:uoYY5M9G1nJVT8ytPIicdTUujcBXKldBw7ijWolU0yU=
 github.com/IBM/secret-utils-lib v1.0.2 h1:AdhKHo/bMmFLMz7+ZjnqSUHuU22CMQsG5meddvwKaV8=

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7 h1:eHgfQl6IeSmzWUyiSi13CvoFYsovoyq
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM/go-sdk-core/v5 v5.9.1 h1:06pXbD9Rgmqqe2HA5YAeQbB4eYRRFgIoOT+Kh3cp1zo=
 github.com/IBM/go-sdk-core/v5 v5.9.1/go.mod h1:axE2JrRq79gIJTjKPBwV6gWHswvVptBjbcvvCPIxARM=
-github.com/IBM/ibmcloud-volume-interface v1.0.1-beta6.0.20220915095958-58768b1f060e h1:YwViMVC1SJebTuc5UiaOTP2g02DVuPj8A8i7Ft75oBc=
-github.com/IBM/ibmcloud-volume-interface v1.0.1-beta6.0.20220915095958-58768b1f060e/go.mod h1:v1aT8G3Tib8pCwdr9VweNFYa94GejBuqIVTysoaVI0g=
+github.com/IBM/ibmcloud-volume-interface v1.0.1-beta7 h1:xnGyxnRiX1yj64rCaYRZ4txlx6lTR6l3BONwKMHH8h0=
+github.com/IBM/ibmcloud-volume-interface v1.0.1-beta7/go.mod h1:v1aT8G3Tib8pCwdr9VweNFYa94GejBuqIVTysoaVI0g=
 github.com/IBM/secret-common-lib v1.0.3 h1:rhhAtAE1ANSuxhA8Nulzzc2IbXWHGE8reoRSr98rRi8=
 github.com/IBM/secret-common-lib v1.0.3/go.mod h1:uoYY5M9G1nJVT8ytPIicdTUujcBXKldBw7ijWolU0yU=
 github.com/IBM/secret-utils-lib v1.0.2 h1:AdhKHo/bMmFLMz7+ZjnqSUHuU22CMQsG5meddvwKaV8=


### PR DESCRIPTION
Below is the custom retry logic

```
MaxVPCRetryAttempt    int    `toml:"max_vpc_retry_attempt,omitempty" envconfig:"MAX_VPC_RETRY_ATTEMPT"`
MinVPCRetryGap        int    `toml:"min_vpc_retry_gap,omitempty" envconfig:"MIN_VPC_RETRY_INTERVAL"`
MinVPCRetryGapAttempt int    `toml:"min_vpc_retry_gap_attempt,omitempty" envconfig:"MIN_VPC_RETRY_INTERVAL_ATTEMPT"`

```
Default MaxVPCRetryAttempt = 46  sec, MinVPCRetryGap = 3 sec , MinVPCRetryGapAttempt = 3 sec
1.) Honour the MinVPCRetryGap only if it is greater than 3 and less than 10 sec
2.) Honour the MinVPCRetryGapAttempt only if it is greater than 0
3.) Honour the MaxVPCRetryAttempt only if it is greater than 46 ( 7 mins default)

**Flow** 

1.) First attempt is immediately after attach was done.
2.) MinVPCRetryGapAttempts will be done with interval MinVPCRetryGap
3.) 2*MinVPCRetryGapAttempts will be done with interval of MinVPCRetryGap*2 ( it will default to 10 sec if it more than 10)
4.) Remaining attempts will be done with interval of 10 secs