### PR TITLE
snapshots should report restore size instead of actual size

### DIFF
--- a/block/provider/util.go
+++ b/block/provider/util.go
@@ -371,7 +371,7 @@ func FromProviderToLibSnapshot(vpcSnapshot *models.Snapshot, logger *zap.Logger)
 		VolumeID:             vpcSnapshot.SourceVolume.ID,
 		SnapshotID:           vpcSnapshot.ID,
 		SnapshotCreationTime: createdTime,
-		SnapshotSize:         GiBToBytes(vpcSnapshot.Size),
+		SnapshotSize:         GiBToBytes(vpcSnapshot.MinimumCapacity),
 		VPC:                  provider.VPC{Href: vpcSnapshot.Href},
 	}
 	if vpcSnapshot.LifecycleState == snapshotReadyState {


### PR DESCRIPTION
When [translating](https://github.com/IBM/ibmcloud-volume-vpc/blob/1e06c9497b820b8ef63ad419280c5506eac91121/block/provider/util.go#L374) from VPC snapshot format to a generic snapshot type we should use `MinimumCapacity` attribute of the VPC snapshot to report a restore size rather than actual size of the snapshot. According to [VPC API reference](https://cloud.ibm.com/apidocs/vpc-beta#create-snapshot-response) the `minimum_capacity` "will be set to the capacity of the `source_volume`" which is what we actually need to report in Kubernetes.

The restore size is used by [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter/blob/6dd7d02a1743ac0cd72247527476f5085e6c2daa/client/apis/volumesnapshot/v1/types.go#L176) and specified by [CSI protocol](https://github.com/container-storage-interface/spec/blob/3b67dfac0de6589644283082540e03ffb338ad03/csi.proto#L1134) as "space needed to create a volume from this snapshot".



Tested on IBM cluster with this patch included, the snapshot restore size matches pvc size:

```
$ [[ `oc get pvc/pvc-1 -o json | jq '.status.capacity.storage'` == `oc get volumesnapshot/pvc-1-snapshot -o json | jq '.status.restoreSize'` ]]; echo $?
0
```

Origin: https://issues.redhat.com/browse/OCPBUGS-4317